### PR TITLE
apply expansions to user deserialization [Fixes #10]

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -54,7 +54,8 @@ function Strategy(o){
     };
 
     self.deserializeUser = function(userHref, done) {
-        self.spClient.getAccount(userHref,function(err,account){
+        var options = self.expansions ? { expand: self.expansions } : null;
+        self.spClient.getAccount(userHref, options, function(err,account){
             done(err,account);
         });
     };


### PR DESCRIPTION
Apply the same expansion to `deserializeUser()` as in the `authenticate()` call.  Fixes #10 .

I see Github's editor also added a newline at EOF.
