### PR TITLE
Adds stormpath error object to the failure reason.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -93,7 +93,7 @@ Strategy.prototype.authenticate = function(req, options) {
 
   self.spApp.authenticateAccount(data, function(err, authenticationResult) {
     if (err) {
-      return self.fail({ message: err.userMessage }, err.status || 500);
+      return self.fail({ message: err.userMessage, stormpathError: err }, err.status || 500);
     } else {
       var options = self.expansions ? { expand: self.expansions } : null;
       authenticationResult.getAccount(options, function(err, account) {


### PR DESCRIPTION
so that it shows up in info, incase the application needs any of the information in there.

An example use case, the application needs to handle "account failed because not verified" this will now expose that on the info so it can be used.